### PR TITLE
Add Professional Training page and update branding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,18 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
+import { useEffect } from "react";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+  useEffect(() => { window.scrollTo(0, 0); }, [pathname]);
+  return null;
+};
 import Layout from "./components/Layout";
 import Index from "./pages/Index";
 import YouthPrograms from "./pages/YouthPrograms";
-// import CorporateTraining from "./pages/CorporateTraining";
+import ProfessionalTraining from "./pages/ProfessionalTraining";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
 import Enrollment from "./pages/Enrollment";
@@ -23,10 +30,11 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Layout>
+          <ScrollToTop />
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/youth-programs" element={<YouthPrograms />} />
-            {/* <Route path="/corporate-training" element={<CorporateTraining />} /> */}
+            <Route path="/professional-training" element={<ProfessionalTraining />} />
             <Route path="/about" element={<About />} />
             <Route path="/contact" element={<Contact />} />
             <Route path="/enrollment" element={<Enrollment />} />

--- a/src/components/ChatBot.tsx
+++ b/src/components/ChatBot.tsx
@@ -31,12 +31,12 @@ const FAQ: { keywords: string[]; answer: string; links?: { label: string; to: st
     },
     {
         keywords: ["online", "virtual", "zoom", "format", "how does it work"],
-        answer: "All student sessions are live online via video call. You just need a computer with a webcam and microphone — no special software required! Our Corporate programs are custom-designed and hence will be online or in-person based on the needs of the business.",
+        answer: "All student sessions are live online via video call. You just need a computer with a webcam and microphone — no special software required! Our Professional programs are custom-designed and hence will be online or in-person based on the needs of the business.",
     },
     {
         keywords: ["corporate", "business", "team", "company", "employee", "training", "workplace"],
-        answer: "We offer customized corporate AI training for teams of all sizes. We're launching Summer 2026 with pilot opportunities available! Please reach out to us on the Contact Us page to sign up or learn more",
-        links: [{ label: "Corporate Training", to: "/corporate-training" }],
+        answer: "We offer customized professional AI training for teams of all sizes. We're launching Summer 2026 with pilot opportunities available! Please reach out to us on the Contact Us page to sign up or learn more",
+        links: [{ label: "Professional Training", to: "/professional-training" }],
     },
 
     {
@@ -49,7 +49,7 @@ const FAQ: { keywords: string[]; answer: string; links?: { label: string; to: st
     },
     {
         keywords: ["contact", "email", "phone", "reach", "talk", "speak", "human"],
-        answer: "You can reach us at AgenticMindsHelp@gmail.com or call/WhatsApp 480-296-1631. We respond within 24 hours on business days.",
+        answer: "You can reach us at Info@AgenticMinds.net or call/WhatsApp 480-296-1631. We respond within 24 hours on business days.",
         links: [{ label: "Contact Page", to: "/contact" }],
     },
     {
@@ -71,7 +71,7 @@ const FAQ: { keywords: string[]; answer: string; links?: { label: string; to: st
 
 const QUICK_QUESTIONS = [
     "Do you offer summer camps?",
-    "Tell me more about the Corporate Programs",
+    "Tell me more about the Professional Programs",
     "How much does it cost?",
     "Is it online?",
 ];

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,7 +14,7 @@ const Footer = () => {
               {[
                 { label: "Home", to: "/" },
                 { label: "Youth Programs", to: "/youth-programs" },
-                // { label: "Corporate Training", to: "/corporate-training" },
+                // { label: "Professional Training", to: "/professional-training" },
                 { label: "About Us", to: "/about" },
                 { label: "Contact", to: "/contact" },
               ].map((l) => (
@@ -32,8 +32,8 @@ const Footer = () => {
               <li><Link to="/youth-programs" className="hover:underline">Youth Overview</Link></li>
               <li><Link to="/youth-programs" className="hover:underline">Middle School</Link></li>
 
-              <li><Link to="/corporate-training" className="hover:underline">Corporate Training</Link></li>
-              <li><Link to="/corporate-training#pilot" className="hover:underline">Pilot Program</Link></li>
+              <li><Link to="/professional-training" className="hover:underline">Professional Training</Link></li>
+              <li><Link to="/professional-training#pilot" className="hover:underline">Pilot Program</Link></li>
             </ul>
           </div>
 
@@ -53,7 +53,7 @@ const Footer = () => {
             <ul className="space-y-2 text-sm opacity-90">
               <li className="flex items-start gap-2">
                 <Mail size={16} className="mt-0.5 shrink-0" />
-                <a href="mailto:AgenticMindsHelp@gmail.com" className="hover:underline">AgenticMindsHelp@gmail.com</a>
+                <a href="mailto:Info@AgenticMinds.net" className="hover:underline">Info@AgenticMinds.net</a>
               </li>
               <li className="flex items-start gap-2">
                 <Phone size={16} className="mt-0.5 shrink-0" />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,8 +7,8 @@ import logoImg from "@/assets/logo.svg";
 
 const navLinks = [
   { label: "Home", to: "/" },
+  { label: "Professional Training", to: "/professional-training" },
   { label: "Youth Programs", to: "/youth-programs" },
-  // { label: "Corporate Training", to: "/corporate-training" },
   { label: "About Us", to: "/about" },
   { label: "Contact", to: "/contact" },
 ];

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -57,7 +57,7 @@ const About = () => {
                 role: "Co-Founder",
                 bg: "Former AI/ML engineer with extensive experience building and deploying AI systems at leading technology companies.",
                 quote: "The best way to prepare for an AI-powered future is to start thinking AI native today—not tomorrow.",
-                expertise: ["AI/ML systems architecture", "Corporate training", "Technical mentorship"],
+                expertise: ["AI/ML systems architecture", "Professional training", "Technical mentorship"],
               },
             ].map((f) => (
               <div key={f.role} className="rounded-2xl bg-surface border border-border p-8">
@@ -145,7 +145,7 @@ const About = () => {
             <Link to="/youth-programs">
               <Button size="lg" className="gradient-accent border-0 text-accent-foreground font-bold px-8 py-6 hover:opacity-90">Explore Youth Programs</Button>
             </Link>
-            {/* <Link to="/corporate-training">
+            {/* <Link to="/professional-training">
               <Button size="lg" variant="outline" className="border-primary-foreground/40 text-primary-foreground bg-primary-foreground/10 hover:bg-primary-foreground/20 font-semibold px-8 py-6">Corporate Training</Button>
             </Link> */}
           </div>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -56,8 +56,8 @@ const Contact = () => {
                     <Mail size={18} className="shrink-0 text-primary mt-0.5" />
                     <div>
                       <p className="font-medium">Email</p>
-                      <a href="mailto:AgenticMindsHelp@gmail.com" className="text-primary hover:underline">
-                        AgenticMindsHelp@gmail.com
+                      <a href="mailto:Info@AgenticMinds.net" className="text-primary hover:underline">
+                        Info@AgenticMinds.net
                       </a>
                     </div>
                   </div>
@@ -112,7 +112,7 @@ const Contact = () => {
               <div className="rounded-xl bg-primary/5 border border-primary/20 p-6">
                 <h3 className="font-bold mb-2">Partnerships & Media</h3>
                 <p className="text-sm text-muted-foreground mb-3">
-                  Interested in collaborating? We're open to partnerships with schools, educational organizations, tech companies, and community groups.
+                  Interested in collaborating? We're open to partnerships with schools, educational organizations, companies, and community groups.
                 </p>
                 <p className="text-sm text-muted-foreground">Press inquiries and interview requests welcome.</p>
               </div>

--- a/src/pages/Enrollment.tsx
+++ b/src/pages/Enrollment.tsx
@@ -328,7 +328,7 @@ const Enrollment = () => {
                 </Link>
               </div>
 
-              <p className="text-sm text-muted-foreground">Need help? <a href="mailto:AgenticMindsHelp@gmail.com" className="text-primary hover:underline">AgenticMindsHelp@gmail.com</a></p>
+              <p className="text-sm text-muted-foreground">Need help? <a href="mailto:Info@AgenticMinds.net" className="text-primary hover:underline">Info@AgenticMinds.net</a></p>
             </div>
           )}
         </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -144,7 +144,7 @@ const Index = () => {
                   </div>
                   <div>
                     <h4 className="font-bold">{title}</h4>
-                    <p className="text-sm text-muted-foreground">{desc}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">{desc}</p>
                   </div>
                 </div>
               ))}
@@ -152,7 +152,7 @@ const Index = () => {
 
             <div className="mt-8 rounded-xl bg-surface-alt p-6">
               <h4 className="font-bold mb-3">By the end of this workshop, you will:</h4>
-              <ul className="grid gap-2 sm:grid-cols-2 text-sm">
+              <ul className="grid gap-2 sm:grid-cols-2 text-sm text-muted-foreground">
                 {[
                   "Generate PRDs, marketing briefs, and sales sequences in 30 minutes instead of 6–8 hours",
                   "Turn messy data exports into clean pipeline reports with trends and at-risk deals flagged",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -114,7 +114,7 @@ const Index = () => {
         <div className="container-narrow">
           <div className="text-center">
             <span className="inline-block rounded-full bg-accent/10 px-4 py-1 text-sm font-semibold text-accent">For Professionals</span>
-            <h2 className="mt-4 text-3xl font-bold md:text-4xl">Professional Training: Real Skills, Real Impact</h2>
+            <h2 className="mt-4 text-3xl font-bold md:text-4xl">AI Training for Professionals: Real Skills, Real Impact</h2>
           </div>
 
           <div className="flex flex-col gap-3 mb-6 mt-12">
@@ -122,7 +122,7 @@ const Index = () => {
               <span className="rounded-full gradient-primary px-4 py-1 text-sm font-bold text-primary-foreground inline-block">
                 AI TRAINING WORKSHOP MAY 30TH – 31ST, 2026
               </span>
-              <span className="text-sm font-bold text-muted-foreground">For Business Leaders &amp; Teams</span>
+
               <Link
                 to="/professional-training"
                 className="inline-flex items-center font-semibold text-sm hover:underline transition"
@@ -241,9 +241,9 @@ const Index = () => {
         <div className="container-narrow">
           <div className="text-center">
             <span className="inline-block rounded-full bg-accent/10 px-4 py-1 text-sm font-semibold text-accent">Coming Summer 2026</span>
-            <h2 className="mt-4 text-3xl font-bold md:text-4xl">Corporate Training: Transform Your Team Into AI Native Leaders</h2>
+            <h2 className="mt-4 text-3xl font-bold md:text-4xl">Professional Training: Transform Your Team Into AI Native Leaders</h2>
             <p className="mt-4 max-w-2xl mx-auto text-muted-foreground text-lg">
-              We're launching customized corporate training for small and medium sized businesses ready to transform how their teams work.
+              We're launching customized professional training for small and medium sized businesses ready to transform how their teams work.
             </p>
           </div>
 
@@ -305,15 +305,15 @@ const Index = () => {
 
             {/* CTAs - SAME SIZE as Youth CTAs */}
             <div className="mt-8 flex flex-wrap items-center gap-4">
-              <Link to="/corporate-training">
+              <Link to="/professional-training">
                 <Button size="lg" className="gradient-accent border-0 text-accent-foreground font-bold px-8 py-6 hover:opacity-90">
-                  Join Corporate Waitlist
+                  Join Professional Waitlist
                 </Button>
               </Link>
-              <Link to="/corporate-training">
-                <Button size="lg" variant="outline" className="font-semibold px-8 py-6">Learn More About Corporate Training</Button>
+              <Link to="/professional-training">
+                <Button size="lg" variant="outline" className="font-semibold px-8 py-6">Learn More About Professional Training</Button>
               </Link>
-              {/* <Link to="/corporate-training#pilot" className="text-sm font-semibold text-accent hover:underline flex items-center gap-1">
+              {/* <Link to="/professional-training#pilot" className="text-sm font-semibold text-accent hover:underline flex items-center gap-1">
                 Apply for Pilot <ArrowRight size={14} />
               </Link> */}
             </div>

--- a/src/pages/ProfessionalTraining.tsx
+++ b/src/pages/ProfessionalTraining.tsx
@@ -1,0 +1,365 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Building2, Users, Target, BarChart3, Rocket, CheckCircle2,
+  Monitor, BookOpen, Lightbulb, Brain, ShieldCheck, TrendingUp, ArrowRight,
+  Zap, Database, Bot, Code2
+} from "lucide-react";
+
+const modules = [
+  {
+    num: 1, title: "AI Foundations", day: "Day 1",
+    icon: Brain,
+    goals: [
+      "Understand how LLMs and generative AI actually work",
+      "Learn how AI agents reason and take action",
+      "Evaluate AI tools and make informed decisions",
+      "Have confident conversations with technical teams",
+    ],
+    usecase: null,
+    keyConcepts: ["LLMs", "Generative AI", "AI Agents", "Hallucinations", "Context Window", "Foundation Models"],
+  },
+  {
+    num: 2, title: "Prompt Engineering", day: "Day 1",
+    icon: Lightbulb,
+    goals: [
+      "Master RICE, chain-of-thought, and few-shot frameworks",
+      "Produce consistent, high-quality AI outputs",
+      "Apply prompting to real business workflows",
+    ],
+    usecase: "Generate PRDs, marketing briefs, and sales sequences in 30 minutes instead of 6–8 hours.",
+  },
+  {
+    num: 3, title: "AI-Powered Data & Analysis", day: "Day 1",
+    icon: Database,
+    goals: [
+      "Use AI with Excel and Google Sheets to clean and analyse data",
+      "Generate instant reports from raw data exports",
+      "Surface trends and flag at-risk items automatically",
+    ],
+    usecase: "Turn a messy data export into a clean pipeline report with trends and at-risk deals flagged.",
+  },
+  {
+    num: 4, title: "AI Agents & Workflow Automation", day: "Day 2",
+    icon: Bot,
+    goals: [
+      "Build functional AI assistants loaded with your team's knowledge",
+      "Create agents that can reason, remember, and take action",
+      "Deploy Skills any team member can use without technical help",
+    ],
+    usecase: "Deploy a Skill that any team member uses to generate on-brand marketing copy without creative review.",
+  },
+  {
+    num: 5, title: "MCPs — Connected AI Workflows", day: "Day 2",
+    icon: Zap,
+    goals: [
+      "Connect AI agents to live tools using the Model Context Protocol",
+      "Integrate with Google Drive, Gmail, and other business tools",
+      "Build fully automated multi-step workflows",
+    ],
+    usecase: "An agent that monitors customer complaints in Gmail, pulls account data, drafts a response, and posts a summary — fully automated.",
+  },
+  {
+    num: 6, title: "Vibe Coding", day: "Day 2",
+    icon: Code2,
+    goals: [
+      "Describe what you want in plain English and build a working app",
+      "Create internal tools with zero coding experience",
+      "Go from idea to demo-ready product in under an hour",
+    ],
+    usecase: "A product manager builds a customer feedback tracker with tagging and priority scoring in 45 minutes — ready to demo.",
+  },
+];
+import { toast } from "sonner";
+import corpImg from "@/assets/corporate-team.jpg";
+
+const ProfessionalTraining = () => {
+  const [formData, setFormData] = useState({
+    firstName: "", lastName: "", email: "", company: "",
+    companySize: "", industry: "", trainingNeed: "",
+    pilotInterest: false, questions: ""
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.firstName || !formData.email || !formData.company) {
+      toast.error("Please fill in all required fields.");
+      return;
+    }
+    toast.success("Thank you! You're on the waitlist. We'll reach out within 2–3 weeks.");
+    setFormData({ firstName: "", lastName: "", email: "", company: "", companySize: "", industry: "", trainingNeed: "", pilotInterest: false, questions: "" });
+  };
+
+  return (
+    <div>
+      {/* Hero */}
+      <section className="relative overflow-hidden gradient-primary">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_50%,hsl(21_90%_48%/0.15),transparent_60%)]" />
+        <div className="container-narrow relative px-4 py-20 md:py-28">
+          <div className="grid items-center gap-12 lg:grid-cols-2">
+            <div className="text-primary-foreground">
+              <span className="inline-block rounded-full bg-accent/20 px-4 py-1 text-sm font-bold text-accent-foreground mb-4">Live Workshop May 30–31, 2026 · Limited Seats — Register Now</span>
+              <h1 className="text-4xl font-bold md:text-5xl text-balance">Professional Training: Transform Your Team Into AI Native Leaders</h1>
+
+              <p className="mt-3 text-sm md:text-base opacity-75">Build AI agents, automate workflows, and drive real business results</p>
+              <div className="mt-8 flex flex-wrap gap-4">
+                <Link to="/contact">
+                  <Button size="lg" className="gradient-accent border-0 text-accent-foreground font-bold px-8 py-6 hover:opacity-90">Sign Up for May Cohort</Button>
+                </Link>
+                {/* <a href="#pilot">
+                  <Button size="lg" variant="outline" className="border-primary-foreground/40 text-primary-foreground bg-primary-foreground/10 hover:bg-primary-foreground/20 font-semibold px-8 py-6">Apply for Pilot</Button>
+                </a> */}
+              </div>
+            </div>
+            <img src={corpImg} alt="Professional team collaborating on AI strategy" className="rounded-2xl shadow-2xl w-full object-cover aspect-video" />
+          </div>
+        </div>
+      </section>
+
+      {/* The Challenge */}
+      <section className="section-padding !pb-6 bg-surface">
+        <div className="container-narrow">
+          <h2 className="text-3xl font-bold md:text-4xl text-center">You Know AI Is Important. But How Do You Actually Become AI Native?</h2>
+          <div className="mt-12 grid gap-6 md:grid-cols-3">
+            {[
+              { icon: Brain, title: "Surface-Level Usage", items: ["Use AI superficially", "Copy-paste prompts without understanding", "No integration into actual workflows", "Productivity gains are minimal"] },
+              { icon: Users, title: "Lack of Expertise", items: ["No internal AI experts to guide", "Overwhelmed by tools and options", "Unclear what 'AI native' even means", "Don't know where to start"] },
+              { icon: BarChart3, title: "ROI Uncertainty", items: ["Hard to measure impact", "Training feels theoretical", "Team doesn't adopt consistently", "Investment doesn't pay off"] },
+            ].map(({ icon: Icon, title, items }) => (
+              <div key={title} className="rounded-xl border border-destructive/20 bg-destructive/5 p-6">
+                <Icon size={28} className="text-destructive mb-3" />
+                <h3 className="font-bold text-lg">{title}</h3>
+                <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                  {items.map((item) => <li key={item}>• {item}</li>)}
+                </ul>
+              </div>
+            ))}
+          </div>
+          <p className="mt-8 mb-0 text-center font-heading text-lg font-semibold text-primary">AgenticMinds solves all three problems with a proven approach.</p>
+        </div>
+      </section>
+
+      {/* Curriculum */}
+      <section className="section-padding !pt-6 bg-surface-alt">
+
+      {/* What Makes Us Different */}
+      {false && (
+      <section className="section-padding bg-surface-alt">
+        <div className="container-narrow">
+          <h2 className="text-3xl font-bold md:text-4xl text-center">What Makes Us Different</h2>
+          <div className="mt-12 grid gap-8 md:grid-cols-3">
+            {[
+              { icon: Lightbulb, title: "Real Tech Experience + Proven Teaching", desc: "Founders built AI native systems at real companies. Combine industry expertise with educational excellence." },
+              { icon: Target, title: "Problem-Based, Not Tool-Based", desc: "Focus on your actual business challenges. Hands-on practice, not passive lectures. Immediate applicability." },
+              { icon: TrendingUp, title: "Refined Through Teaching", desc: "Adaptable to different learning styles. Know how to make complex concepts accessible." },
+            ].map(({ icon: Icon, title, desc }) => (
+              <div key={title} className="rounded-xl bg-surface border border-border p-8 text-center">
+                <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-xl bg-accent/10 mb-4">
+                  <Icon size={28} className="text-accent" />
+                </div>
+                <h3 className="font-bold text-lg">{title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      )}
+
+      {/* Why Choose Us */}
+      {false && (
+      <section className="section-padding bg-surface">
+        <div className="container-narrow">
+          <h2 className="text-3xl font-bold md:text-4xl text-center">Why Choose AgenticMinds?</h2>
+          <div className="mt-12 grid gap-8 md:grid-cols-3">
+            {[
+              { icon: BookOpen, title: "Proven Methodology", items: ["Problem-based learning that drives adoption", "Focus on thinking patterns, not just tools", "Real results with real students"] },
+              { icon: Building2, title: "Tech Industry Expertise", items: ["Founders built AI native systems professionally", "Understand business contexts and constraints", "Stay current with rapidly evolving landscape"] },
+              { icon: BarChart3, title: "Results-Focused", items: ["Emphasize ROI from day one", "Track adoption and productivity metrics", "Long-term partnership, not one-time event"] },
+            ].map(({ icon: Icon, title, items }) => (
+              <div key={title} className="rounded-xl bg-surface-alt border border-border p-8">
+                <Icon size={28} className="text-accent mb-3" />
+                <h3 className="font-bold text-lg">{title}</h3>
+                <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                  {items.map((item) => <li key={item} className="flex items-start gap-2"><CheckCircle2 size={14} className="mt-0.5 shrink-0 text-accent" />{item}</li>)}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      )}
+        <div className="container-narrow">
+          <div className="text-center">
+            <h2 className="text-3xl font-bold md:text-4xl">Curriculum: 6 Modules</h2>
+            <p className="mt-4 text-muted-foreground max-w-2xl mx-auto">8 hours across 2 days — designed for complete beginners. No tech background needed.</p>
+          </div>
+          <div className="mt-12 space-y-6 max-w-4xl mx-auto">
+            {modules.map((mod) => {
+              const Icon = mod.icon;
+              return (
+                <div key={mod.num} className="rounded-2xl border border-border bg-surface p-8">
+                  <div className="flex items-center gap-4 mb-4">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-full gradient-accent text-accent-foreground font-bold text-sm">{mod.num}</span>
+                    <div className="flex-1">
+                      <div className="flex items-center gap-3">
+                        <h3 className="text-lg font-bold">{mod.title}</h3>
+                        <Icon size={18} className="text-accent" />
+                      </div>
+                      <span className="text-sm text-muted-foreground">{mod.day}</span>
+                    </div>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <h4 className="text-sm font-bold mb-2">What You'll Learn</h4>
+                      <ul className="space-y-1 text-sm text-muted-foreground">
+                        {mod.goals.map((g) => <li key={g} className="flex items-start gap-2"><CheckCircle2 size={14} className="mt-0.5 shrink-0 text-success" />{g}</li>)}
+                      </ul>
+                    </div>
+                    {mod.usecase && (
+                      <div>
+                        <h4 className="text-sm font-bold mb-2">Sample Use Case</h4>
+                        <p className="text-sm text-muted-foreground italic">"{mod.usecase}"</p>
+                      </div>
+                    )}
+                    {!mod.usecase && mod.keyConcepts && (
+                      <div>
+                        <h4 className="text-sm font-bold mb-2">Key Concepts</h4>
+                        <div className="flex flex-wrap gap-2">
+                          {mod.keyConcepts.map((c) => (
+                            <span key={c} className="rounded-full bg-accent/10 px-3 py-1 text-xs font-semibold text-accent">{c}</span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Pilot Program */}
+      {false && (
+      <section id="pilot" className="section-padding bg-surface-alt">
+        <div className="container-narrow max-w-4xl">
+          <div className="rounded-2xl gradient-accent p-8 md:p-12 text-accent-foreground">
+            <div className="flex items-center gap-3 mb-4">
+              <Rocket size={28} />
+              <h2 className="text-2xl md:text-3xl font-bold">Join the Summer 2026 cohort</h2>
+            </div>
+            <p className="opacity-90">We're selecting 2–3 companies to participate in our Summer 2026 program.</p>
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              {[
+                "Customized program design for your industry",
+                "Direct access to founders",
+                "Proven frameworks built from real-world experience, not theory",
+                "Priority support and iteration",
+                "Faster time-to-value with a structured, hands-on approach",
+                "Join a vetted peer network of like-minded founders and operators"
+              ].map((item) => (
+                <div key={item} className="flex items-start gap-2 text-sm"><CheckCircle2 size={16} className="mt-0.5 shrink-0" />{item}</div>
+              ))}
+            </div>
+            <div className="mt-6">
+              <h4 className="font-bold mb-2">Requirements:</h4>
+              <ul className="text-sm space-y-1 opacity-90">
+                <li>• SMB (50–500 employees)</li>
+                <li>• Commitment to full program participation</li>
+                <li>• Willingness to provide feedback</li>
+                <li>• Available Summer 2026</li>
+                <li>• Open to being a reference client</li>
+              </ul>
+            </div>
+            <p className="mt-4 text-sm font-bold">Timeline: Pilot programs begin Summer 2026. Very limited availability.</p>
+            <a href="#waitlist" className="mt-6 inline-block">
+              <Button size="lg" className="bg-primary-foreground text-primary font-bold px-8 py-6 hover:opacity-90">Apply for Pilot Program</Button>
+            </a>
+          </div>
+        </div>
+      </section>
+      )}
+
+      {/* Waitlist */}
+      {false && (
+      <section id="waitlist" className="section-padding bg-surface">
+        <div className="container-narrow max-w-2xl">
+          <h2 className="text-3xl font-bold md:text-4xl text-center">Join the Waitlist</h2>
+          <p className="mt-4 text-center text-muted-foreground">Be first to know when we launch. Get early access pricing and priority scheduling.</p>
+          <form onSubmit={handleSubmit} className="mt-12 space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <Label htmlFor="firstName">First Name *</Label>
+                <Input id="firstName" value={formData.firstName} onChange={(e) => setFormData({ ...formData, firstName: e.target.value })} required />
+              </div>
+              <div>
+                <Label htmlFor="lastName">Last Name *</Label>
+                <Input id="lastName" value={formData.lastName} onChange={(e) => setFormData({ ...formData, lastName: e.target.value })} required />
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="email">Work Email *</Label>
+              <Input id="email" type="email" value={formData.email} onChange={(e) => setFormData({ ...formData, email: e.target.value })} required />
+            </div>
+            <div>
+              <Label htmlFor="company">Company Name *</Label>
+              <Input id="company" value={formData.company} onChange={(e) => setFormData({ ...formData, company: e.target.value })} required />
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <Label>Company Size</Label>
+                <Select value={formData.companySize} onValueChange={(v) => setFormData({ ...formData, companySize: v })}>
+                  <SelectTrigger><SelectValue placeholder="Select size" /></SelectTrigger>
+                  <SelectContent>
+                    {["1-50", "51-100", "101-250", "251-500", "500+"].map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Industry</Label>
+                <Select value={formData.industry} onValueChange={(v) => setFormData({ ...formData, industry: v })}>
+                  <SelectTrigger><SelectValue placeholder="Select industry" /></SelectTrigger>
+                  <SelectContent>
+                    {["Technology", "Healthcare", "Finance", "Manufacturing", "Retail", "Education", "Professional Services", "Other"].map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div>
+              <Label>Primary Training Need</Label>
+              <Select value={formData.trainingNeed} onValueChange={(v) => setFormData({ ...formData, trainingNeed: v })}>
+                <SelectTrigger><SelectValue placeholder="Select need" /></SelectTrigger>
+                <SelectContent>
+                  {["Executive strategic planning", "Team workflow transformation", "Department-specific training", "Company-wide rollout", "Not sure yet"].map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-3">
+              <Checkbox id="pilot" checked={formData.pilotInterest} onCheckedChange={(c) => setFormData({ ...formData, pilotInterest: !!c })} />
+              <Label htmlFor="pilot" className="text-sm">Interested in pilot program?</Label>
+            </div>
+            <div>
+              <Label htmlFor="questions">Any specific questions? (optional)</Label>
+              <Textarea id="questions" value={formData.questions} onChange={(e) => setFormData({ ...formData, questions: e.target.value })} maxLength={1000} />
+            </div>
+            <Button type="submit" size="lg" className="w-full gradient-accent border-0 text-accent-foreground font-bold py-6 hover:opacity-90">
+              Join Waitlist
+            </Button>
+          </form>
+        </div>
+      </section>
+      )}
+    </div>
+  );
+};
+
+export default ProfessionalTraining;

--- a/src/pages/YouthPrograms.tsx
+++ b/src/pages/YouthPrograms.tsx
@@ -82,7 +82,7 @@ const YouthPrograms = () => {
               <div className="mt-8 flex flex-wrap gap-4">
 
                 <Link to="/contact">
-                  <Button size="lg" variant="outline" className="border-primary-foreground/40 text-primary-foreground bg-primary-foreground/10 hover:bg-primary-foreground/20 font-semibold px-8 py-6">Sign Up for May Cohort</Button>
+                  <Button size="lg" className="gradient-accent border-0 text-accent-foreground font-bold px-8 py-6 hover:opacity-90">Sign Up for May Cohort</Button>
                 </Link>
               </div>
             </div>
@@ -133,28 +133,17 @@ const YouthPrograms = () => {
       </section>
 
       {/* Program Overview */}
-      <section className="section-padding bg-surface">
+      <section className="section-padding !pt-6 !pb-6 bg-surface">
         <div className="container-narrow">
           <h2 className="text-3xl font-bold md:text-4xl text-center">Program Overview</h2>
-          <div className="mt-12 grid gap-8 md:grid-cols-2">
-            {/* Weekly */}
+          <div className="mt-12 max-w-xl mx-auto">
             <div className="rounded-2xl border border-border bg-surface p-8">
-              <span className="inline-block rounded-full bg-primary/10 px-3 py-1 text-xs font-bold text-primary mb-4">Option A</span>
+              <span className="inline-block rounded-full bg-primary/10 px-3 py-1 text-xs font-bold text-primary mb-4">May Cohort</span>
               <h3 className="text-xl font-bold">Weekly Sessions</h3>
               <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
-                <li><strong>Duration:</strong> 12 weeks</li>
-                <li><strong>Schedule:</strong> 1 hour/week + optional practice</li>
-                <li><strong>Best for:</strong> Consistent learning throughout school year</li>
-              </ul>
-            </div>
-            {/* Summer */}
-            <div className="rounded-2xl border border-border bg-surface p-8">
-              <span className="inline-block rounded-full bg-secondary/10 px-3 py-1 text-xs font-bold text-secondary mb-4">Option B</span>
-              <h3 className="text-xl font-bold">Spring Break Camp 2026</h3>
-              <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
-                <li><strong>Duration:</strong> 1 week online intensive</li>
-                <li><strong>Schedule:</strong> April 6 - April 10 2026</li>
-                <li><strong>Best for:</strong> AI Imersive spring learning experience</li>
+                <li><strong>Duration:</strong> 5 weeks</li>
+                <li><strong>Schedule:</strong> 1.5 hours/day + optional practice</li>
+                <li><strong>Best for:</strong> Consistent learning with live instructor guidance</li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Add Professional Training page with hero, curriculum (6 modules with use cases), and challenge section
- Rename Corporate Training → Professional Training throughout (nav, footer, chatbot, links, URLs)
- Update URL paths from `/corporate-training` to `/professional-training`
- Add ScrollToTop component for proper page navigation
- Update email to Info@AgenticMinds.net across all pages
- Update Youth Programs overview to May Cohort details (5 weeks, 1.5hrs/day)
- Various copy and spacing improvements

## Test plan
- [ ] Professional Training page loads at `/professional-training`
- [ ] Nav shows Professional Training before Youth Programs
- [ ] All links to Professional Training route correctly
- [ ] Sign Up for May Cohort buttons link to Contact page
- [ ] Navigating between pages scrolls to top
- [ ] Email shows Info@AgenticMinds.net in footer, contact, and chatbot

🤖 Generated with [Claude Code](https://claude.com/claude-code)